### PR TITLE
fix: change Task and TaskList position fields from int to float

### DIFF
--- a/src/favro_mcp/api/models.py
+++ b/src/favro_mcp/api/models.py
@@ -169,7 +169,7 @@ class TaskList(BaseModel):
     organization_id: str = Field(alias="organizationId")
     card_common_id: str = Field(alias="cardCommonId")
     name: str
-    position: int
+    position: float
 
 
 class Task(BaseModel):
@@ -181,4 +181,4 @@ class Task(BaseModel):
     card_common_id: str = Field(alias="cardCommonId")
     name: str
     completed: bool
-    position: int
+    position: float


### PR DESCRIPTION
## Summary
- Changed `TaskList.position` from `int` to `float` in `src/favro_mcp/api/models.py`
- Changed `Task.position` from `int` to `float` in `src/favro_mcp/api/models.py`

The Favro API returns float values for task positions to support fractional positioning (e.g., inserting between positions 1 and 2 yields 1.5). This was causing Pydantic validation errors like:
```
Input should be a valid integer, got a number with a fractional part [type=int_from_float, input_value=3.125, input_type=float]
```

Resolves #8

## Test plan
- [x] Verified `get_card_details` works on cards with tasks having decimal positions (3.125, 1.5, 4.25)
- [x] Confirmed the error occurs on `main` branch and is fixed on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)