### PR TITLE
fix: request markdown format for card descriptions

### DIFF
--- a/src/favro_mcp/api/client.py
+++ b/src/favro_mcp/api/client.py
@@ -376,6 +376,7 @@ class FavroClient:
             params["cardSequentialId"] = str(card_sequential_id)
         if todo_list:
             params["todoList"] = "true"
+        params["descriptionFormat"] = "markdown"
         entities = self._paginate_all("/cards", params)
         return [Card.model_validate(e) for e in entities]
 
@@ -411,12 +412,13 @@ class FavroClient:
             params["cardSequentialId"] = str(card_sequential_id)
         if todo_list:
             params["todoList"] = "true"
+        params["descriptionFormat"] = "markdown"
         entities, total_pages = self._paginate_single("/cards", params, page)
         return [Card.model_validate(e) for e in entities], total_pages
 
     def get_card(self, card_id: str) -> Card:
         """Get a specific card."""
-        data = self._get(f"/cards/{card_id}")
+        data = self._get(f"/cards/{card_id}", params={"descriptionFormat": "markdown"})
         return Card.model_validate(data)
 
     def create_card(


### PR DESCRIPTION
## Summary
- Pass `descriptionFormat=markdown` to all card GET endpoints (`get_cards`, `get_cards_page`, `get_card`) so descriptions preserve formatting instead of being returned as plaintext
- Fixes #15

## Test plan
- [x] Verified card #2706 returns plaintext without fix (headings stripped, `•` instead of `*`, no code fences)
- [x] Verified same card returns proper markdown with fix (`#` headings, `*` lists, `1.` numbered lists, triple-backtick code blocks, `---` rules, markdown tables)

🤖 Generated with [Claude Code](https://claude.com/claude-code)