### PR TITLE
feat: add user lookup tools

### DIFF
--- a/src/favro_mcp/tools/__init__.py
+++ b/src/favro_mcp/tools/__init__.py
@@ -1,5 +1,5 @@
 """MCP Tools for Favro - mutation operations."""
 
-from favro_mcp.tools import boards, cards, collections, columns, organizations
+from favro_mcp.tools import boards, cards, collections, columns, organizations, users
 
-__all__ = ["boards", "cards", "collections", "columns", "organizations"]
+__all__ = ["boards", "cards", "collections", "columns", "organizations", "users"]

--- a/src/favro_mcp/tools/users.py
+++ b/src/favro_mcp/tools/users.py
@@ -1,0 +1,58 @@
+"""User tools for Favro MCP."""
+
+from typing import Any
+
+from fastmcp import Context
+
+from favro_mcp.context import get_favro_context
+from favro_mcp.resolvers import UserResolver
+from favro_mcp.server import mcp
+
+
+@mcp.tool
+def list_users(ctx: Context) -> dict[str, Any]:
+    """List all users in the current organization.
+
+    Returns:
+        A list of users with their IDs, names, emails, and roles.
+    """
+    favro_ctx = get_favro_context(ctx)
+    favro_ctx.require_org()
+    with favro_ctx.get_client() as client:
+        users = client.get_users()
+        result = [
+            {
+                "user_id": user.user_id,
+                "name": user.name,
+                "email": user.email,
+                "organization_role": user.organization_role,
+            }
+            for user in users
+        ]
+        return {"users": result, "count": len(result)}
+
+
+@mcp.tool
+def get_user(user: str, ctx: Context) -> dict[str, Any]:
+    """Look up a user by ID, name, or email address.
+
+    Useful for resolving user IDs returned in card details (e.g. assignments,
+    comments) to human-readable user information.
+
+    Args:
+        user: User ID, name, or email address
+
+    Returns:
+        User details including ID, name, email, and organization role.
+    """
+    favro_ctx = get_favro_context(ctx)
+    favro_ctx.require_org()
+    with favro_ctx.get_client() as client:
+        resolver = UserResolver(client)
+        resolved = resolver.resolve(user)
+        return {
+            "user_id": resolved.user_id,
+            "name": resolved.name,
+            "email": resolved.email,
+            "organization_role": resolved.organization_role,
+        }


### PR DESCRIPTION
## Summary
- Adds `list_users` tool to list all users in the current organization
- Adds `get_user` tool to look up a user by ID, name, or email address
- Leverages existing `UserResolver` and `FavroClient.get_users()`/`get_user()` methods

Closes #20

## Test plan
- [x] Verified `list_users` returns all 34 org users against live Favro API
- [x] Verified `get_user` resolves by ID, name, and email
- [x] Confirmed module imports and registers correctly with FastMCP

🤖 Generated with [Claude Code](https://claude.com/claude-code)