### PR TITLE
feat: add attachment upload support for cards

### DIFF
--- a/src/favro_mcp/api/client.py
+++ b/src/favro_mcp/api/client.py
@@ -5,6 +5,7 @@ from typing import Any, TypeVar
 import httpx
 
 from favro_mcp.api.models import (
+    Attachment,
     Card,
     Collection,
     Column,
@@ -176,6 +177,24 @@ class FavroClient:
             path,
             params=params,
             headers=self._get_headers(include_org),
+        )
+        return self._handle_response(response)
+
+    def _post_binary(
+        self,
+        path: str,
+        content: bytes,
+        params: dict[str, str] | None = None,
+        include_org: bool = True,
+    ) -> dict[str, Any]:
+        """Make a POST request with raw binary body."""
+        headers = self._get_headers(include_org)
+        headers["Content-Type"] = "application/octet-stream"
+        response = self._client.post(
+            path,
+            content=content,
+            params=params,
+            headers=headers,
         )
         return self._handle_response(response)
 
@@ -544,6 +563,24 @@ class FavroClient:
         """Delete a card."""
         params = {"everywhere": "true"} if everywhere else None
         self._delete(f"/cards/{card_id}", params)
+
+    # Attachment endpoints
+    def upload_attachment(self, card_id: str, filename: str, content: bytes) -> Attachment:
+        """Upload a file attachment to a card.
+
+        Args:
+            card_id: The card ID to attach to
+            filename: Name for the uploaded file
+            content: Raw file bytes (max 10 MB)
+        """
+        if len(content) > 10 * 1024 * 1024:
+            raise ValueError("File size exceeds 10 MB limit")
+        data = self._post_binary(
+            f"/cards/{card_id}/attachment",
+            content=content,
+            params={"filename": filename},
+        )
+        return Attachment.model_validate(data)
 
     # Tag endpoints
     def get_tags(self) -> list[Tag]:

--- a/src/favro_mcp/api/models.py
+++ b/src/favro_mcp/api/models.py
@@ -182,3 +182,10 @@ class Task(BaseModel):
     name: str
     completed: bool
     position: float
+
+
+class Attachment(BaseModel):
+    """Attachment model."""
+
+    name: str
+    file_url: str = Field(alias="fileURL")

--- a/src/favro_mcp/tools/cards.py
+++ b/src/favro_mcp/tools/cards.py
@@ -1,5 +1,6 @@
 """Card tools for Favro MCP."""
 
+import pathlib
 from typing import Any
 
 from fastmcp import Context
@@ -615,4 +616,46 @@ def delete_card(
         return {
             "message": f"Deleted card: {card_name}",
             "card_id": card_id,
+        }
+
+
+@mcp.tool
+def upload_attachment(
+    card: str,
+    file_path: str,
+    ctx: Context,
+    board: str | None = None,
+) -> dict[str, Any]:
+    """Upload a file attachment to a card.
+
+    Args:
+        card: Card ID, sequential ID (#123), or name
+        file_path: Absolute path to the file to upload (max 10 MB)
+        board: Board ID or name (needed for name lookups)
+
+    Returns:
+        The attachment name and URL.
+    """
+    favro_ctx = get_favro_context(ctx)
+    favro_ctx.require_org()
+
+    path = pathlib.Path(file_path)
+    if not path.is_file():
+        raise ValueError(f"File not found: {file_path}")
+
+    content = path.read_bytes()
+
+    with favro_ctx.get_client() as client:
+        board_id = board or favro_ctx.current_board_id
+        if board:
+            board_id = BoardResolver(client).resolve(board).widget_common_id
+
+        c = CardResolver(client).resolve(card, board_id=board_id)
+        attachment = client.upload_attachment(c.card_id, path.name, content)
+
+        return {
+            "message": f"Uploaded '{attachment.name}' to card '{c.name}'",
+            "name": attachment.name,
+            "file_url": attachment.file_url,
+            "card_id": c.card_id,
         }


### PR DESCRIPTION
## Summary

- Add `upload_attachment` MCP tool that uploads local files to Favro cards
- Add `Attachment` model, `_post_binary` client method, and `upload_attachment` client method
- Uses the Favro `POST /cards/:cardId/attachment` endpoint with raw binary upload
- Validates 10 MB file size limit before uploading

Closes #22

## Test plan

- [x] Tested against live Favro API — successfully uploaded a text file to a card
- [x] Pyright type checking passes with 0 errors
- [ ] Manual test: upload an image file and verify thumbnail generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)