### PR TITLE
Easier filtering of cards: timeOnColumns, archived, list_tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,12 @@ See [Codex MCP documentation](https://developers.openai.com/codex/mcp/) for more
 | `delete_card`        | Delete a card        |
 | `list_custom_fields` | List custom fields   |
 
+### Tags
+
+| Tool        | Description                |
+| ----------- | -------------------------- |
+| `list_tags` | List all tags              |
+
 ### Columns
 
 | Tool            | Description           |

--- a/src/favro_mcp/api/client.py
+++ b/src/favro_mcp/api/client.py
@@ -354,6 +354,7 @@ class FavroClient:
         card_sequential_id: int | None = None,
         todo_list: bool = False,
         unique: bool = True,
+        archived: bool | None = None,
     ) -> list[Card]:
         """Get all cards from the organization (fetches all pages).
 
@@ -364,6 +365,7 @@ class FavroClient:
             card_sequential_id: Filter by card sequential ID (e.g., 123 for #123)
             todo_list: Include todo list items
             unique: Return unique cards only
+            archived: If True, return only archived cards. If False, only non-archived.
         """
         params: dict[str, str] = {"unique": "true" if unique else "false"}
         if widget_common_id:
@@ -376,6 +378,8 @@ class FavroClient:
             params["cardSequentialId"] = str(card_sequential_id)
         if todo_list:
             params["todoList"] = "true"
+        if archived is not None:
+            params["archived"] = "true" if archived else "false"
         params["descriptionFormat"] = "markdown"
         try:
             entities = self._paginate_all("/cards", params)
@@ -395,6 +399,7 @@ class FavroClient:
         card_sequential_id: int | None = None,
         todo_list: bool = False,
         unique: bool = True,
+        archived: bool | None = None,
         page: int = 0,
     ) -> tuple[list[Card], int]:
         """Get a single page of cards.
@@ -406,6 +411,7 @@ class FavroClient:
             card_sequential_id: Filter by card sequential ID (e.g., 123 for #123)
             todo_list: Include todo list items
             unique: Return unique cards only
+            archived: If True, return only archived cards. If False, only non-archived.
             page: Page number (0-indexed)
         """
         params: dict[str, str] = {"unique": "true" if unique else "false"}
@@ -419,6 +425,8 @@ class FavroClient:
             params["cardSequentialId"] = str(card_sequential_id)
         if todo_list:
             params["todoList"] = "true"
+        if archived is not None:
+            params["archived"] = "true" if archived else "false"
         params["descriptionFormat"] = "markdown"
         try:
             entities, total_pages = self._paginate_single("/cards", params, page)

--- a/src/favro_mcp/api/models.py
+++ b/src/favro_mcp/api/models.py
@@ -135,6 +135,7 @@ class Card(BaseModel):
     tasks_done: int = Field(default=0, alias="tasksDone")
     custom_fields: list[CardCustomField] = Field(default=[], alias="customFields")
     time_on_board: CardTimeOnBoard | None = Field(default=None, alias="timeOnBoard")
+    time_on_columns: dict[str, int] | None = Field(default=None, alias="timeOnColumns")
     todo_list_user_id: str | None = Field(default=None, alias="todoListUserId")
     todo_list_completed: bool | None = Field(default=None, alias="todoListCompleted")
     list_position: float | None = Field(default=None, alias="listPosition")

--- a/src/favro_mcp/tools/__init__.py
+++ b/src/favro_mcp/tools/__init__.py
@@ -1,5 +1,5 @@
 """MCP Tools for Favro - mutation operations."""
 
-from favro_mcp.tools import boards, cards, collections, columns, organizations
+from favro_mcp.tools import boards, cards, collections, columns, organizations, tags
 
-__all__ = ["boards", "cards", "collections", "columns", "organizations"]
+__all__ = ["boards", "cards", "collections", "columns", "organizations", "tags"]

--- a/src/favro_mcp/tools/cards.py
+++ b/src/favro_mcp/tools/cards.py
@@ -82,6 +82,7 @@ def _card_to_dict(card: Card) -> dict[str, Any]:
         "tasks_done": card.tasks_done,
         "tasks_total": card.tasks_total,
         "time_on_board": card.time_on_board,
+        "time_on_columns": card.time_on_columns,
         "custom_fields": [
             {
                 "custom_field_id": cf.custom_field_id,

--- a/src/favro_mcp/tools/cards.py
+++ b/src/favro_mcp/tools/cards.py
@@ -102,6 +102,7 @@ def list_cards(
     board: str,
     ctx: Context,
     column: str | None = None,
+    archived: bool | None = None,
     page: int = 0,
 ) -> dict[str, Any]:
     """List cards on a specific board with pagination.
@@ -109,6 +110,7 @@ def list_cards(
     Args:
         board: The board's widget_common_id, name, or ID
         column: Optional column ID or name to filter by
+        archived: Filter by archived status. True = only archived, False = only non-archived, None = all (default).
         page: Page number (0-indexed, default 0). Each page contains up to 100 cards.
 
     Returns:
@@ -127,6 +129,7 @@ def list_cards(
         cards, total_pages = client.get_cards_page(
             widget_common_id=board_id,
             column_id=column_id,
+            archived=archived,
             page=page,
         )
 

--- a/src/favro_mcp/tools/tags.py
+++ b/src/favro_mcp/tools/tags.py
@@ -1,0 +1,31 @@
+"""Tag tools for Favro MCP."""
+
+from typing import Any
+
+from fastmcp import Context
+
+from favro_mcp.context import get_favro_context
+from favro_mcp.server import mcp
+
+
+@mcp.tool
+def list_tags(ctx: Context) -> dict[str, Any]:
+    """List all tags in the organization.
+
+    Returns:
+        A list of tags with their IDs, names, and colors.
+        Use the tag name or ID with tag_card() to add/remove tags from cards.
+    """
+    favro_ctx = get_favro_context(ctx)
+    favro_ctx.require_org()
+    with favro_ctx.get_client() as client:
+        tags = client.get_tags()
+        result = [
+            {
+                "tag_id": tag.tag_id,
+                "name": tag.name,
+                "color": tag.color,
+            }
+            for tag in tags
+        ]
+        return {"tags": result, "count": len(result)}


### PR DESCRIPTION
We had a case where we wanted Claude to look for cards that had been moved to a specific column during the last week, and filter those. This PR adds some of the metrics that we needed:

* **New value** `time_on_columns` is added next to `time_on_board`, this is pretty self-explanatory and matches the existing board timing. Just straight up exposing 1 more field from the underlying Favro API. (Minor increase of context usage.)
  
* **New filter** `archived` is added to the `list_cards` tool. This was because we were over-stuffing our context with all archived cards. The board is a few years old. Previously we had to tell Claude in the prompt to only look at “the last two pages of results”, but now we can simply exclude archived cards. (Big decrease of context usage.)
  
* **New tool** `list_tags` is added to the server. This is to get the name of tags. Otherwise Claude was unable to filter by human tag names as the `get_card_details` only exposes tags by their ID.

I considered adding `time_on_board` and `time_on_columns` to the output of the `list_cards` tool, as it would have allowed filtering without having to retrieve details for every card. But that would have been a bigger increase to the context usage so I opted against that.

Let me know if you want me to make any changes, or would prefer to get these as separate PRs!