### PR TITLE
fix: move cards between boards instead of copying them

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ See [Codex MCP documentation](https://developers.openai.com/codex/mcp/) for more
 | `add_comment`        | Add a comment to card |
 | `create_card`        | Create a card        |
 | `update_card`        | Update a card        |
-| `move_card`          | Move card to column  |
+| `move_card`          | Move card to column or another board |
 | `assign_card`        | Assign/unassign user |
 | `tag_card`           | Add/remove tag       |
 | `delete_card`        | Delete a card        |

--- a/src/favro_mcp/api/client.py
+++ b/src/favro_mcp/api/client.py
@@ -511,6 +511,7 @@ class FavroClient:
         widget_common_id: str | None = None,
         column_id: str | None = None,
         lane_id: str | None = None,
+        drag_mode: str | None = None,
         add_tags: list[str] | None = None,
         remove_tags: list[str] | None = None,
         start_date: str | None = None,
@@ -524,6 +525,10 @@ class FavroClient:
         """Update a card.
 
         Args:
+            drag_mode: How to apply a widget_common_id change. "commit" (Favro's
+                default) adds the card to the target board while keeping the
+                existing instance (a copy); "move" relocates the instance off the
+                source board. Pass "move" to move a card between boards.
             custom_fields: List of custom field updates. Each dict should contain
                 'customFieldId' and the appropriate value field for the field type:
                 - Text: {'customFieldId': '...', 'value': 'text'}
@@ -546,6 +551,8 @@ class FavroClient:
             data["columnId"] = column_id
         if lane_id is not None:
             data["laneId"] = lane_id
+        if drag_mode is not None:
+            data["dragMode"] = drag_mode
         if add_tags:
             data["addTagIds"] = add_tags
         if remove_tags:

--- a/src/favro_mcp/resolvers/card.py
+++ b/src/favro_mcp/resolvers/card.py
@@ -76,10 +76,16 @@ class CardResolver(BaseResolver[Card]):
         # Check if it's a sequential ID
         seq_id = self._parse_sequential_id(identifier)
         if seq_id is not None:
-            # Use cardSequentialId API parameter - more efficient than fetching all
+            # Use cardSequentialId API parameter - more efficient than fetching all.
+            # unique=False so a card committed to several boards comes back as one
+            # row per board instance. That lets us detect an ambiguous instance and
+            # refuse to guess, instead of silently returning an arbitrary one
+            # (each board instance has its own card_id; acting on the wrong
+            # instance is why moves/assignments hit the wrong board).
             cards = self.client.get_cards(
                 widget_common_id=board_id,  # Optional filter by board
                 card_sequential_id=seq_id,
+                unique=False,
             )
 
             if len(cards) == 0:
@@ -87,9 +93,14 @@ class CardResolver(BaseResolver[Card]):
             elif len(cards) == 1:
                 return cards[0]
             else:
-                # Multiple matches - shouldn't happen within an org, but handle it
+                # Same card lives on multiple boards: refuse to pick an instance.
+                # Narrow the lookup by passing the board the card lives on.
                 match_info = [
-                    (self._get_id(c), f"#{c.sequential_id}: {self._get_name(c)}")
+                    (
+                        self._get_id(c),
+                        f"#{c.sequential_id} on board {c.widget_common_id}: "
+                        f"{self._get_name(c)}",
+                    )
                     for c in cards
                 ]
                 raise AmbiguousMatchError(self.entity_type, identifier, match_info)

--- a/src/favro_mcp/tools/cards.py
+++ b/src/favro_mcp/tools/cards.py
@@ -491,13 +491,24 @@ def move_card(
     column: str,
     ctx: Context,
     board: str | None = None,
+    to_board: str | None = None,
 ) -> dict[str, Any]:
-    """Move a card to a different column.
+    """Move a card to a different column, optionally on another board.
+
+    A card can be committed to several boards at once. Favro's API treats a
+    board change as "commit" (add to the target board, keep the original) by
+    default, which looks like a copy; this tool uses "move" so a cross-board
+    move actually relocates the card.
 
     Args:
-        card: Card ID, sequential ID (#123), or name
-        column: Target column ID or name
-        board: Board ID or name (needed for name lookups)
+        card: Card ID, sequential ID (#123), or name.
+        column: Target column ID or name (on to_board if given, else on the
+            card's current board).
+        board: Source board ID or name — where the card currently lives. Used
+            to resolve the correct card instance when the card exists on more
+            than one board. Defaults to the current board context.
+        to_board: Destination board ID or name. Omit to move within the same
+            board.
 
     Returns:
         The updated card details
@@ -505,27 +516,48 @@ def move_card(
     favro_ctx = get_favro_context(ctx)
     favro_ctx.require_org()
     with favro_ctx.get_client() as client:
-        board_id = board or favro_ctx.current_board_id
+        source_board = board or favro_ctx.current_board_id
         if board:
-            board_id = BoardResolver(client).resolve(board).widget_common_id
+            source_board = BoardResolver(client).resolve(board).widget_common_id
 
-        c = CardResolver(client).resolve(card, board_id=board_id)
+        c = CardResolver(client).resolve(card, board_id=source_board)
 
-        # Use the card's board if not specified
-        target_board = board_id or c.widget_common_id
+        # Make sure we resolved the instance on the intended source board, so we
+        # move the right one (each board instance has its own card_id).
+        if source_board and c.widget_common_id and c.widget_common_id != source_board:
+            raise ValueError(
+                f"Card '{card}' resolved to board {c.widget_common_id}, not the "
+                f"source board {source_board}. Pass 'board' as the board the card "
+                "currently lives on."
+            )
+
+        # Destination board: explicit to_board, else the card's current board.
+        target_board = source_board or c.widget_common_id
+        if to_board:
+            target_board = BoardResolver(client).resolve(to_board).widget_common_id
         if not target_board:
-            raise ValueError("Board ID required to resolve column")
+            raise ValueError("Board ID required to resolve the target column")
 
         col = ColumnResolver(client).resolve(column, board_id=target_board)
+
+        # Only a board change needs drag mode; a same-board column move does not.
+        cross_board = target_board != c.widget_common_id
         updated = client.update_card(
             card_id=c.card_id,
             column_id=col.column_id,
             widget_common_id=target_board,
+            drag_mode="move" if cross_board else None,
         )
 
+        location = (
+            f"to board {target_board} column '{col.name}'"
+            if cross_board
+            else f"to column '{col.name}'"
+        )
         return {
-            "message": f"Moved card '{updated.name}' to column '{col.name}'",
+            "message": f"Moved card '{updated.name}' {location}",
             "card_id": updated.card_id,
+            "widget_common_id": target_board,
             "column_id": col.column_id,
             "column_name": col.name,
         }


### PR DESCRIPTION
## Problem

Moving a card from one board to another with `move_card` **copied** it instead of moving it. Favro's `PUT /cards/{cardId}` defaults `dragMode` to `"commit"`, which adds the card to the target board while keeping the original instance. `move_card` never set `dragMode`, and its single `board` param served as both the resolution scope and the move target — so there was no way to express "move from board A to board B".

Separately, resolving a card by sequential ID (`#123`) with no board silently picked **one arbitrary board instance** of a card committed to multiple boards. Each instance has its own `card_id`, so downstream actions (move, assign, tag) could act on the wrong board.

## Changes

- **`client.update_card`**: new `drag_mode` param, sent as Favro's `dragMode`.
- **`move_card`**: new `to_board` (destination) distinct from `board` (source — where the card currently lives, used to resolve the right instance). Sends `dragMode="move"` for cross-board moves, and verifies the resolved instance is on the intended source board before moving. Same-board column moves are unchanged.
- **`CardResolver`**: resolves sequential IDs with `unique=false` so a card on multiple boards raises `AmbiguousMatchError` (listing the boards) instead of acting on an arbitrary instance.

## Behavior change to note

Resolving a sequential ID for a card that lives on **several** boards now requires specifying the board, instead of picking an instance arbitrarily. Single-board cards are unaffected. This touches every tool that resolves cards by `#id` (`get_card_details`, `assign_card`, `tag_card`, `move_card`, …).

## Testing

- `pyright`: 0 errors on changed files.
- Module import / tool registration verified.
- No automated test suite exists on `main`; the logic was traced manually across same-board, cross-board, multi-board-ambiguous, and raw-`card_id` scenarios.

Source for the `dragMode` behavior: Favro API "Update a card" — https://favro.com/developer/

🤖 Generated with [Claude Code](https://claude.com/claude-code)
