### PR TITLE
feat: list swimlanes and set a card's lane

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,8 +214,9 @@ See [Codex MCP documentation](https://developers.openai.com/codex/mcp/) for more
 | ------------ | ---------------------------- |
 | `list_lanes` | List lanes (swimlanes) on board |
 
-Lanes are read-only in the Favro API (no create/rename/delete). Use a `lane_id`
-from `list_lanes` as the `lane_id` argument to `create_card` / `update_card`.
+Lanes themselves are read-only in the Favro API (no create/rename/delete). To
+place a card in a lane, pass its ID or name as the `lane` argument to
+`create_card`, `update_card`, or `move_card` (use `list_lanes` to discover them).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -208,6 +208,15 @@ See [Codex MCP documentation](https://developers.openai.com/codex/mcp/) for more
 | `move_column`   | Move column position  |
 | `delete_column` | Delete a column       |
 
+### Lanes (Swimlanes)
+
+| Tool         | Description                  |
+| ------------ | ---------------------------- |
+| `list_lanes` | List lanes (swimlanes) on board |
+
+Lanes are read-only in the Favro API (no create/rename/delete). Use a `lane_id`
+from `list_lanes` as the `lane_id` argument to `create_card` / `update_card`.
+
 ---
 
 ## Development

--- a/src/favro_mcp/api/client.py
+++ b/src/favro_mcp/api/client.py
@@ -10,6 +10,7 @@ from favro_mcp.api.models import (
     Collection,
     Column,
     Comment,
+    Lane,
     Organization,
     Tag,
     Task,
@@ -316,6 +317,14 @@ class FavroClient:
         """Get a specific widget (board)."""
         data = self._get(f"/widgets/{widget_common_id}")
         return Widget.model_validate(data)
+
+    def get_lanes(self, widget_common_id: str) -> list[Lane]:
+        """Get all lanes (swimlanes) for a widget.
+
+        Lanes are read-only and returned nested in the widget object; a board
+        without lanes enabled yields an empty list.
+        """
+        return self.get_widget(widget_common_id).lanes
 
     # Column endpoints
     def get_columns(self, widget_common_id: str) -> list[Column]:

--- a/src/favro_mcp/api/models.py
+++ b/src/favro_mcp/api/models.py
@@ -55,6 +55,17 @@ class Collection(BaseModel):
     public_sharing: str | None = Field(default=None, alias="publicSharing")
 
 
+class Lane(BaseModel):
+    """Lane (swimlane) model.
+
+    Lanes are read-only in the Favro API: they are returned nested in the
+    widget object and cannot be created, updated, or deleted via the API.
+    """
+
+    lane_id: str = Field(alias="laneId")
+    name: str
+
+
 class Widget(BaseModel):
     """Widget (board) model."""
 
@@ -70,6 +81,7 @@ class Widget(BaseModel):
     breakdown_card_common_id: str | None = Field(
         default=None, alias="breakdownCardCommonId"
     )
+    lanes: list[Lane] = Field(default=[])
 
 
 class Column(BaseModel):

--- a/src/favro_mcp/resolvers/__init__.py
+++ b/src/favro_mcp/resolvers/__init__.py
@@ -4,6 +4,7 @@ from .base import AmbiguousMatchError, NotFoundError, ResolverError
 from .board import BoardResolver
 from .card import CardResolver
 from .column import ColumnResolver
+from .lane import LaneResolver
 from .organization import OrganizationResolver
 from .tag import TagResolver
 from .user import UserResolver
@@ -13,6 +14,7 @@ __all__ = [
     "BoardResolver",
     "CardResolver",
     "ColumnResolver",
+    "LaneResolver",
     "NotFoundError",
     "OrganizationResolver",
     "ResolverError",

--- a/src/favro_mcp/resolvers/lane.py
+++ b/src/favro_mcp/resolvers/lane.py
@@ -1,0 +1,65 @@
+"""Lane resolver (requires board context; lanes have no by-id endpoint)."""
+
+from favro_mcp.api.models import Lane
+
+from .base import AmbiguousMatchError, BaseResolver, NotFoundError
+
+
+class LaneResolver(BaseResolver[Lane]):
+    """Resolver for lanes (swimlanes).
+
+    Lanes are only exposed nested in the widget object, so resolution always
+    requires board_id context. There is no GET /lanes/:id endpoint, so both ID
+    and name are matched against the board's lanes rather than fetched directly.
+    """
+
+    entity_type = "lane"
+
+    def _fetch_all(
+        self, board_id: str | None = None, **context: str | None
+    ) -> list[Lane]:
+        if board_id is None:
+            raise ValueError("board_id is required to resolve lanes")
+        return self.client.get_lanes(board_id)
+
+    def _fetch_by_id(self, entity_id: str) -> Lane | None:
+        # Lanes have no dedicated GET endpoint; resolution happens via resolve().
+        return None
+
+    def _get_id(self, entity: Lane) -> str:
+        return entity.lane_id
+
+    def _get_name(self, entity: Lane) -> str:
+        return entity.name
+
+    def resolve(self, identifier: str, **context: str | None) -> Lane:
+        """Resolve a lane by ID or name within a board.
+
+        Args:
+            identifier: Lane ID or name
+            **context: Must include board_id
+
+        Returns:
+            The resolved lane
+
+        Raises:
+            NotFoundError: No lane matches
+            AmbiguousMatchError: Multiple lanes share the given name
+        """
+        lanes = self._fetch_all(**context)
+
+        # Exact ID match first (no by-id endpoint, so search the board's lanes)
+        for lane in lanes:
+            if lane.lane_id == identifier:
+                return lane
+
+        # Then case-insensitive name match
+        matches = [
+            lane for lane in lanes if lane.name.lower() == identifier.lower()
+        ]
+        if len(matches) == 1:
+            return matches[0]
+        if len(matches) == 0:
+            raise NotFoundError(self.entity_type, identifier)
+        match_info = [(lane.lane_id, lane.name) for lane in matches]
+        raise AmbiguousMatchError(self.entity_type, identifier, match_info)

--- a/src/favro_mcp/tools/__init__.py
+++ b/src/favro_mcp/tools/__init__.py
@@ -1,5 +1,23 @@
 """MCP Tools for Favro - mutation operations."""
 
-from favro_mcp.tools import boards, cards, collections, columns, organizations, tags, users
+from favro_mcp.tools import (
+    boards,
+    cards,
+    collections,
+    columns,
+    lanes,
+    organizations,
+    tags,
+    users,
+)
 
-__all__ = ["boards", "cards", "collections", "columns", "organizations", "tags", "users"]
+__all__ = [
+    "boards",
+    "cards",
+    "collections",
+    "columns",
+    "lanes",
+    "organizations",
+    "tags",
+    "users",
+]

--- a/src/favro_mcp/tools/boards.py
+++ b/src/favro_mcp/tools/boards.py
@@ -85,6 +85,9 @@ def get_board(board_id: str, ctx: Context) -> dict[str, Any]:
                 }
                 for col in sorted(columns, key=lambda c: c.position)
             ],
+            "lanes": [
+                {"lane_id": lane.lane_id, "name": lane.name} for lane in board.lanes
+            ],
         }
 
 
@@ -115,6 +118,9 @@ def get_current_board(ctx: Context) -> dict[str, Any]:
                     "card_count": col.card_count,
                 }
                 for col in sorted(columns, key=lambda c: c.position)
+            ],
+            "lanes": [
+                {"lane_id": lane.lane_id, "name": lane.name} for lane in board.lanes
             ],
         }
 

--- a/src/favro_mcp/tools/cards.py
+++ b/src/favro_mcp/tools/cards.py
@@ -11,6 +11,7 @@ from favro_mcp.resolvers import (
     BoardResolver,
     CardResolver,
     ColumnResolver,
+    LaneResolver,
     TagResolver,
     UserResolver,
 )
@@ -297,6 +298,7 @@ def create_card(
     ctx: Context,
     board: str | None = None,
     column: str | None = None,
+    lane: str | None = None,
     description: str | None = None,
     tags: list[str] | None = None,
     assignees: list[str] | None = None,
@@ -307,6 +309,8 @@ def create_card(
         name: Card name/title
         board: Board ID or name (uses current board if not specified)
         column: Column ID or name to place the card in
+        lane: Lane (swimlane) ID or name to place the card in. Only applies to
+            boards with lanes enabled; use list_lanes to see available lanes.
         description: Detailed description. Favro supports a subset of Markdown:
             **bold**, *italic*, ~~strikethrough~~, `inline code`, ```code blocks```,
             [links](url), bullet lists, numbered lists, headings (# and ##
@@ -335,6 +339,11 @@ def create_card(
         if column:
             column_id = ColumnResolver(client).resolve(column, board_id=board_id).column_id
 
+        # Resolve lane if provided
+        lane_id = None
+        if lane:
+            lane_id = LaneResolver(client).resolve(lane, board_id=board_id).lane_id
+
         # Resolve tags if provided
         tag_ids = None
         if tags:
@@ -356,6 +365,7 @@ def create_card(
             name=name,
             widget_common_id=board_id,
             column_id=column_id,
+            lane_id=lane_id,
             detailed_description=" " if description else None,
             tags=tag_ids,
             assignments=user_ids,
@@ -383,6 +393,7 @@ def update_card(
     board: str | None = None,
     name: str | None = None,
     description: str | None = None,
+    lane: str | None = None,
     archived: bool | None = None,
     custom_fields: list[dict[str, Any]] | None = None,
     tasks: list[dict[str, Any]] | None = None,
@@ -403,6 +414,8 @@ def update_card(
             unsupported syntax causes the entire description to be stored as
             plain text. For checklists, use the add_tasklist and add_task
             parameters instead.
+        lane: Lane (swimlane) ID or name to move the card into. Only applies to
+            boards with lanes enabled; use list_lanes to see available lanes.
         archived: Archive or unarchive the card
         custom_fields: List of custom field updates. Each dict should contain
             'customFieldId' and the appropriate value field for the field type:
@@ -433,6 +446,14 @@ def update_card(
 
         c = CardResolver(client).resolve(card, board_id=board_id)
 
+        # Resolve lane if provided (falls back to the card's own board)
+        lane_id = None
+        if lane:
+            lane_board = board_id or c.widget_common_id
+            if not lane_board:
+                raise ValueError("Board required to resolve lane")
+            lane_id = LaneResolver(client).resolve(lane, board_id=lane_board).lane_id
+
         # Favro only parses markdown if detailedDescription already has
         # content.  Prime the field with a space when it is currently empty.
         if description:
@@ -445,6 +466,7 @@ def update_card(
             card_id=c.card_id,
             name=name,
             detailed_description=description,
+            lane_id=lane_id,
             archived=archived,
             custom_fields=custom_fields,
         )
@@ -488,20 +510,28 @@ def update_card(
 @mcp.tool
 def move_card(
     card: str,
-    column: str,
     ctx: Context,
+    column: str | None = None,
+    lane: str | None = None,
     board: str | None = None,
 ) -> dict[str, Any]:
-    """Move a card to a different column.
+    """Move a card to a different column and/or lane (swimlane).
+
+    Specify a column, a lane, or both. Lanes only apply to boards with lanes
+    enabled; use list_lanes to see available lanes.
 
     Args:
         card: Card ID, sequential ID (#123), or name
         column: Target column ID or name
+        lane: Target lane (swimlane) ID or name
         board: Board ID or name (needed for name lookups)
 
     Returns:
         The updated card details
     """
+    if not column and not lane:
+        raise ValueError("Specify a column and/or a lane to move the card.")
+
     favro_ctx = get_favro_context(ctx)
     favro_ctx.require_org()
     with favro_ctx.get_client() as client:
@@ -514,20 +544,29 @@ def move_card(
         # Use the card's board if not specified
         target_board = board_id or c.widget_common_id
         if not target_board:
-            raise ValueError("Board ID required to resolve column")
+            raise ValueError("Board ID required to resolve the target column/lane")
 
-        col = ColumnResolver(client).resolve(column, board_id=target_board)
+        col = ColumnResolver(client).resolve(column, board_id=target_board) if column else None
+        ln = LaneResolver(client).resolve(lane, board_id=target_board) if lane else None
+
         updated = client.update_card(
             card_id=c.card_id,
-            column_id=col.column_id,
+            column_id=col.column_id if col else None,
+            lane_id=ln.lane_id if ln else None,
             widget_common_id=target_board,
         )
 
+        destinations = [d for d in (
+            f"column '{col.name}'" if col else None,
+            f"lane '{ln.name}'" if ln else None,
+        ) if d]
         return {
-            "message": f"Moved card '{updated.name}' to column '{col.name}'",
+            "message": f"Moved card '{updated.name}' to " + " and ".join(destinations),
             "card_id": updated.card_id,
-            "column_id": col.column_id,
-            "column_name": col.name,
+            "column_id": col.column_id if col else None,
+            "column_name": col.name if col else None,
+            "lane_id": ln.lane_id if ln else None,
+            "lane_name": ln.name if ln else None,
         }
 
 

--- a/src/favro_mcp/tools/lanes.py
+++ b/src/favro_mcp/tools/lanes.py
@@ -1,0 +1,45 @@
+"""Lane (swimlane) tools for Favro MCP."""
+
+from typing import Any
+
+from fastmcp import Context
+
+from favro_mcp.context import get_favro_context
+from favro_mcp.resolvers import BoardResolver
+from favro_mcp.server import mcp
+
+
+@mcp.tool
+def list_lanes(ctx: Context, board: str | None = None) -> dict[str, Any]:
+    """List the lanes (swimlanes) on a board.
+
+    Lanes are read-only in the Favro API and cannot be created, renamed, or
+    deleted. Use a returned lane_id as the `lane_id` argument to create_card or
+    update_card to place a card in a specific lane. A board without lanes
+    enabled returns an empty list.
+
+    Args:
+        board: The board's widget_common_id, name, or ID.
+               Uses the current board if not specified.
+
+    Returns:
+        A list of lanes with their IDs and names.
+    """
+    favro_ctx = get_favro_context(ctx)
+    favro_ctx.require_org()
+    with favro_ctx.get_client() as client:
+        board_id = board or favro_ctx.current_board_id
+        if not board_id:
+            raise ValueError("No board specified and no current board selected.")
+        if board:
+            board_id = BoardResolver(client).resolve(board).widget_common_id
+
+        lanes = client.get_lanes(board_id)
+        result = [
+            {
+                "lane_id": lane.lane_id,
+                "name": lane.name,
+            }
+            for lane in lanes
+        ]
+        return {"lanes": result}


### PR DESCRIPTION
## Summary

Adds support for Favro board **lanes (swimlanes)** — both listing them and placing cards in them.

Investigation of the Favro API confirmed lanes are **not** first-class CRUD resources: there is no `/lanes` endpoint, `isLane` is read-only, and lanes are only exposed nested in the widget object as `{ laneId, name }`. Cards reference a lane via `laneId`. So this PR adds the two things the API actually supports: reading lanes, and setting a card's lane.

## Changes

**List lanes**
- Add `Lane` model and a `lanes` field on `Widget`.
- Add `FavroClient.get_lanes(widget_common_id)` (reads from the widget; empty list when lanes aren't enabled).
- Add a `list_lanes` MCP tool (resolves board by id/name, or uses the current board).
- Include `lanes` in `get_board` / `get_current_board` output.

**Set a card's lane**
- Add a `LaneResolver` (board-scoped; matches by lane id or name, since lanes have no by-id endpoint).
- Add a `lane` argument (id or name) to `create_card`, `update_card`, and `move_card`.
- `move_card`'s `column` is now optional — specify a column, a lane, or both.

- Document lanes in the README.

## Out of scope

Creating, renaming, or deleting lanes — the Favro API provides no endpoints for these.

## Testing

- `pyright` (strict): 0 errors.
- Verified all tools register; `create_card` / `update_card` / `move_card` expose `lane`, and `move_card` no longer requires `column`.
- **Live end-to-end test against the real API** (fully reversible): created a card in a lane *by name*, verified `lane_id`; moved it to another lane *by name*, verified `lane_id`; deleted the throwaway card.

Closes #27